### PR TITLE
fix(scripts)(#142): add host_permissions to manifest.common.json

### DIFF
--- a/scripts/manifest.common.json
+++ b/scripts/manifest.common.json
@@ -19,5 +19,8 @@
         "contextMenus",
         "storage",
         "scripting"
+    ],
+    "host_permissions": [
+        "*://*/*"
     ]
 }


### PR DESCRIPTION
Fix AdguardTeam/AdguardForWindows#5778

It should fix the extension is not active until clicked