### PR TITLE
Fix Firefox (Nightly) native messaging resilience and popup hang on macOS

### DIFF
--- a/src/background/api/nativeHostApi.js
+++ b/src/background/api/nativeHostApi.js
@@ -11,9 +11,35 @@ import {
     REQUEST_TYPES,
 } from '../../lib/types';
 import { consent } from '../consent';
+import { browserApi } from '../../lib/browserApi';
 import { getErrorMessage } from '../../lib/errors';
 
 import AbstractApi from './AbstractApi';
+
+/** Retries help Firefox Nightly on macOS where native messaging can be briefly unavailable (see AG #145). */
+const NATIVE_HOST_CONNECT_ATTEMPTS_DEFAULT = 6;
+/** Fewer, shorter backoffs when the native manifest is missing (avoids multi-minute “loading”). */
+const NATIVE_HOST_CONNECT_ATTEMPTS_FIREFOX = 5;
+const NATIVE_HOST_CONNECT_BASE_DELAY_MS_DEFAULT = 75;
+const NATIVE_HOST_CONNECT_BASE_DELAY_MS_FIREFOX = 100;
+const NATIVE_HOST_CONNECT_BACKOFF_CAP_MS_DEFAULT = 4000;
+const NATIVE_HOST_CONNECT_BACKOFF_CAP_MS_FIREFOX = 1500;
+
+const delay = (ms) => new Promise((resolve) => {
+    setTimeout(resolve, ms);
+});
+
+const getNativeConnectAttempts = () => (
+    browserApi.utils.isFirefoxBrowser
+        ? NATIVE_HOST_CONNECT_ATTEMPTS_FIREFOX
+        : NATIVE_HOST_CONNECT_ATTEMPTS_DEFAULT
+);
+
+const getNativeConnectBaseDelayMs = () => (
+    browserApi.utils.isFirefoxBrowser
+        ? NATIVE_HOST_CONNECT_BASE_DELAY_MS_FIREFOX
+        : NATIVE_HOST_CONNECT_BASE_DELAY_MS_DEFAULT
+);
 
 /**
  * Module implements methods used to communicate with native host via native messaging
@@ -91,29 +117,104 @@ export class NativeHostApi extends AbstractApi {
      * @param {object} port
      * @returns {string | null | undefined} chrome or firefox error
      */
-    getError = (port) => browser.runtime.lastError?.message || port.error;
+    getError = (port) => browser.runtime.lastError?.message || port?.error;
+
+    /**
+     * Host closed the pipe; port is already dead — do not call disconnect().
+     * Without this, Firefox keeps a stale port and later postMessage fails while "connected".
+     */
+    releaseDisconnectedPort = (disconnectedPort) => {
+        if (!disconnectedPort || this.port !== disconnectedPort) {
+            return;
+        }
+        try {
+            this.port.onMessage.removeListener(this.incomingMessageHandler);
+            this.port.onDisconnect.removeListener(this.disconnectHandler);
+        } catch (e) {
+            log.debug(e);
+        }
+        this.port = null;
+        log.info('Native host port released after disconnect; next request will reconnect.');
+    };
 
     disconnectHandler = (port) => {
         const error = this.getError(port);
 
         if (error) {
-            log.error(error);
+            log.error(`Native host disconnected: ${error}`);
         }
+        this.releaseDisconnectedPort(port);
+    };
+
+    /**
+     * Drops the native port and listeners. Safe when the port never fully connected.
+     */
+    destroyNativePort = () => {
+        if (!this.port) {
+            return;
+        }
+        try {
+            this.port.onMessage.removeListener(this.incomingMessageHandler);
+            this.port.onDisconnect.removeListener(this.disconnectHandler);
+        } catch (e) {
+            log.debug(e);
+        }
+        try {
+            this.port.disconnect();
+        } catch (e) {
+            log.debug(e);
+        }
+        this.port = null;
     };
 
     /**
      * Connect to the native host
      */
     connect = async () => {
-        log.info('Connecting to the native host');
-        // if the extension was connected to the native host in mv3 then it will not die after 30 seconds as usually
-        this.port = browser.runtime.connectNative(HOST_TYPES.browserExtensionHost);
+        const maxAttempts = getNativeConnectAttempts();
+        const baseDelayMs = getNativeConnectBaseDelayMs();
+        const backoffCapMs = browserApi.utils.isFirefoxBrowser
+            ? NATIVE_HOST_CONNECT_BACKOFF_CAP_MS_FIREFOX
+            : NATIVE_HOST_CONNECT_BACKOFF_CAP_MS_DEFAULT;
+        const extensionId = browser.runtime.id;
 
-        this.port.onMessage.addListener(this.incomingMessageHandler);
+        log.info(
+            'Connecting to native host',
+            HOST_TYPES.browserExtensionHost,
+            `extensionId=${extensionId}`,
+        );
 
-        this.port.onDisconnect.addListener(this.disconnectHandler);
+        if (browserApi.utils.isFirefoxBrowser) {
+            await delay(baseDelayMs);
+        }
 
-        await this.sendInitialRequest(false);
+        let lastError;
+        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+            this.destroyNativePort();
+            try {
+                // MV3: once connected, the port stays alive (unlike the usual ~30s native messaging limit).
+                this.port = browser.runtime.connectNative(HOST_TYPES.browserExtensionHost);
+                this.port.onMessage.addListener(this.incomingMessageHandler);
+                this.port.onDisconnect.addListener(this.disconnectHandler);
+                await this.sendInitialRequest(false);
+                if (attempt > 1) {
+                    log.info(`Native host connected on attempt ${attempt}/${maxAttempts}`);
+                }
+                return;
+            } catch (e) {
+                lastError = e;
+                log.warn(
+                    `Native host connect attempt ${attempt}/${maxAttempts} failed:`,
+                    getErrorMessage(e),
+                );
+                if (attempt < maxAttempts) {
+                    const backoff = baseDelayMs * (2 ** (attempt - 1));
+                    await delay(Math.min(backoff, backoffCapMs));
+                }
+            }
+        }
+        this.destroyNativePort();
+        throw lastError;
     };
 
     sendInitialRequest = async (shouldReconnect) => {
@@ -127,8 +228,7 @@ export class NativeHostApi extends AbstractApi {
      */
     disconnect = () => {
         log.debug('Disconnecting from native host');
-        this.port.disconnect();
-        this.port.onMessage.removeListener(this.incomingMessageHandler);
+        this.destroyNativePort();
     };
 
     /**
@@ -150,6 +250,17 @@ export class NativeHostApi extends AbstractApi {
         const isConsentRequired = await consent.isConsentRequired();
         if (isConsentRequired && params.type !== REQUEST_TYPES.init) {
             throw new Error('Requests to native host can be send only after consent agreement received');
+        }
+
+        // Startup connect may fail on Firefox Nightly; establish port when the popup first talks to the host.
+        if (params.type !== REQUEST_TYPES.init && !this.port) {
+            try {
+                await this.connect();
+            } catch (e) {
+                log.warn('Deferred native connect before request failed:', getErrorMessage(e));
+                // Do not fall through: null port + makeRequestOnce caused long hangs and a second full reconnect().
+                throw e;
+            }
         }
 
         try {

--- a/src/background/getPopupData.js
+++ b/src/background/getPopupData.js
@@ -1,12 +1,73 @@
+import { log } from '../lib/logger';
+import { getErrorMessage } from '../lib/errors';
+
 import state from './state';
 import { tabsService } from './TabsService';
 import filteringPause from './filteringPause';
+
+const APP_STATE_FETCH_RETRIES = 2;
+const APP_STATE_RETRY_DELAY_MS = 400;
+/** Prevents infinite popup loading if native messaging hangs (no manifest / dead port). */
+const GET_APP_STATE_TIMEOUT_MS = 20000;
+
+const sleep = (ms) => new Promise((resolve) => {
+    setTimeout(resolve, ms);
+});
+
+const withTimeout = (promise, ms, timeoutMessage) => new Promise((resolve, reject) => {
+    const t = setTimeout(() => {
+        reject(new Error(timeoutMessage));
+    }, ms);
+    promise.then(
+        (v) => {
+            clearTimeout(t);
+            resolve(v);
+        },
+        (e) => {
+            clearTimeout(t);
+            reject(e instanceof Error ? e : new Error(getErrorMessage(e)));
+        },
+    );
+});
+
+const NATIVE_HOST_TIMEOUT_HINT = 'AdGuard did not answer in time. On Mac, Firefox needs the native host file at '
+    + '~/Library/Application Support/Mozilla/NativeMessagingHosts/com.adguard.browser_extension_host.nm.json '
+    + '(created when AdGuard for Mac registers Browser Assistant for Firefox). Open AdGuard → Settings → '
+    + 'Browser Assistant / integration and ensure Firefox is enabled, or reinstall AdGuard.';
 
 const getPopupData = async (tab) => {
     const { url } = tab;
 
     try {
-        await state.getCurrentAppState();
+        let lastError;
+        for (let attempt = 1; attempt <= APP_STATE_FETCH_RETRIES; attempt += 1) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await withTimeout(
+                    state.getCurrentAppState(),
+                    GET_APP_STATE_TIMEOUT_MS,
+                    NATIVE_HOST_TIMEOUT_HINT,
+                );
+                lastError = null;
+                break;
+            } catch (e) {
+                lastError = e;
+                log.warn(
+                    `getCurrentAppState attempt ${attempt}/${APP_STATE_FETCH_RETRIES}:`,
+                    getErrorMessage(e),
+                );
+                if (attempt < APP_STATE_FETCH_RETRIES) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await sleep(APP_STATE_RETRY_DELAY_MS);
+                }
+            }
+        }
+        if (lastError) {
+            const err = lastError instanceof Error
+                ? lastError
+                : new Error(getErrorMessage(lastError));
+            throw err;
+        }
     } catch (e) {
         return {
             appState: state.getAppState(),

--- a/src/popup/stores/settingsStore/index.js
+++ b/src/popup/stores/settingsStore/index.js
@@ -169,6 +169,7 @@ class SettingsStore {
 
         runInAction(() => {
             this.referrer = referrer;
+            this.hostError = null;
             this.setUrlFilteringState(currentFilteringState);
             this.setCurrentAppState(appState);
             this.setUpdateStatusInfo(updateStatusInfo);


### PR DESCRIPTION
### Summary

Improves **AdGuard Browser Assistant** when using **native messaging** with **Firefox** (including **Nightly**) on **macOS**: more reliable `connectNative`, no stale port after disconnect, reconnect when the popup opens if there is no port, and a **bounded wait** so the popup does not load indefinitely when the host is missing or stuck.

Fixes / relates to **#145**.

### Problem

1. Background can connect before native messaging is ready; one failed connect left bad state.
2. After `onDisconnect`, `this.port` stayed set; later requests failed (UI: brief “launching” then “not installed”).
3. If startup `connect()` failed, the popup did not always run a full `connect()` before requests.
4. Failed deferred `connect()` was swallowed; code continued to `makeRequestOnce` + `reconnect()`, causing very long waits.
5. `getCurrentAppState()` could hang → infinite-feeling popup load.
6. `hostError` was not cleared on a successful load.

### Changes

- **`nativeHostApi.js`**: Firefox-specific retry count, initial delay, backoff cap; `connect()` retry loop; `destroyNativePort` / `releaseDisconnectedPort`; log `extensionId` + host; `makeRequest` reconnects before non-init requests and **rethrows** if `connect()` fails.
- **`getPopupData.js`**: `withTimeout` (20s) around `getCurrentAppState`, 2 retries, 400ms gap.
- **`settingsStore/index.js`**: clear `hostError` on successful popup data.

### Limitations

Does **not** install `~/Library/Application Support/Mozilla/NativeMessagingHosts/com.adguard.browser_extension_host.nm.json`. **AdGuard for Mac** must register Firefox native messaging; without that file, Firefox cannot talk to the host. This PR makes failure **fast and predictable** instead of hanging.

### Test plan

1. With valid native host + AdGuard running: popup reaches normal UI on Firefox Release and Nightly.
2. With manifest removed/renamed: popup stops loading within timeout, no endless spinner.

### Build

`BUILD_ENV=release npx ts-node scripts/bundle firefox` → `build/release/firefox.zip`
